### PR TITLE
fix(ox_core/client): player object is not optional

### DIFF
--- a/types/ox_core/client_ox.lua
+++ b/types/ox_core/client_ox.lua
@@ -4,5 +4,5 @@
 Ox = {}
 
 ---**`client`**
----@return OxPlayerClient?
+---@return OxPlayerClient
 function Ox.GetPlayer() end


### PR DESCRIPTION
- fixed typo from #1 
the player object always exists on client
